### PR TITLE
Fixed two problems

### DIFF
--- a/data/rx.listdb/functions/impl/generate.py
+++ b/data/rx.listdb/functions/impl/generate.py
@@ -32,10 +32,10 @@ def make_file(path, content):
 def gen_bit(bit_num):
     bit = (
         'data modify storage rx:global listdb.entries[].bits.select set value 0b\n'
-        'scoreboard players operation $bit rx.temp = $uid rx.temp\n'
+        'scoreboard players operation $bit rx.temp = $idx rx.temp\n'
         f'scoreboard players operation $bit rx.temp %= ${BASE} rx.int\n'
         f'function rx.listdb:impl/select/bit{bit_num}/0_{BASE-1}\n'
-        f'scoreboard players operation $uid rx.temp /= ${BASE} rx.int\n'
+        f'scoreboard players operation $idx rx.temp /= ${BASE} rx.int\n'
         'data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b\n'
         'execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]\n'  # noqa: E501
         f'execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit{bit_num+1}\n'  # noqa: E501

--- a/data/rx.listdb/functions/impl/get.mcfunction
+++ b/data/rx.listdb/functions/impl/get.mcfunction
@@ -10,4 +10,4 @@ execute if score $selected rx.temp matches 1 run data modify storage rx:io listd
 execute if score $selected rx.temp matches 1 run data remove storage rx:io listdb.entry.bits
 
 #> else, clear rx:io
-data remove storage rx:io listdb.entry
+execute if score $selected rx.temp matches 0 run data remove storage rx:io listdb.entry

--- a/data/rx.listdb/functions/impl/select/bit0.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit0.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit0/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit1

--- a/data/rx.listdb/functions/impl/select/bit1.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit1.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit1/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit2

--- a/data/rx.listdb/functions/impl/select/bit2.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit2.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit2/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit3

--- a/data/rx.listdb/functions/impl/select/bit3.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit3.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit3/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit4

--- a/data/rx.listdb/functions/impl/select/bit4.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit4.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit4/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit5

--- a/data/rx.listdb/functions/impl/select/bit5.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit5.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit5/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit6

--- a/data/rx.listdb/functions/impl/select/bit6.mcfunction
+++ b/data/rx.listdb/functions/impl/select/bit6.mcfunction
@@ -1,9 +1,9 @@
 # By: rx97
 data modify storage rx:global listdb.entries[].bits.select set value 0b
-scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp = $idx rx.temp
 scoreboard players operation $bit rx.temp %= $64 rx.int
 function rx.listdb:impl/select/bit6/0_63
-scoreboard players operation $uid rx.temp /= $64 rx.int
+scoreboard players operation $idx rx.temp /= $64 rx.int
 data modify storage rx:global listdb.entries[{bits:{select:0b}}].selected set value 0b
 execute store result score $size rx.temp if data storage rx:global listdb.entries[{selected:1b}]
 execute if score $size rx.temp matches 2.. run function rx.listdb:impl/select/bit7


### PR DESCRIPTION
- Entries aren't being selected at all. I analysed the data pack and I found out that the bit selection function tree uses '$uid rx.temp' score instead of '$idx rx.temp' which would always result in a failure. I assume you updated the names and forgot to update those files as well;
- Get API doesn't work either. Looks like you forgot to include 'if score $selected rx.temp maches 0' in 'rx.listdb:impl/get', it completely ignores the if/else condition and it clears rx:io even if the get operation was successful.